### PR TITLE
Fix typo and add correct path to file

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,7 +95,7 @@ This project follows the [all-contributors](https://github.com/all-contributors/
 
 When triggered by the `push` event, the script looks for added `*.tweet` files in the `tweets/` folder or subfolders. If there are any, a tweet for each added tweet file is published.
 
-If there is no `tweets/` subfolder, the scripts opens a pull request creating the folder with further instructions.
+If there is no `tweets/` subfolder, the script opens a pull request creating the folder with further instructions.
 
 ### The `pull_request` event
 

--- a/README.md
+++ b/README.md
@@ -68,7 +68,7 @@ Happy collaborative tweeting!
 
 All contributions welcome!
 
-Especially if you try `twitter-together` for the first time, I’d love to hear if you ran into any trouble. I greately appreciate any documentation improvements to make things more clear, I am not a native English speaker myself.
+Especially if you try `twitter-together` for the first time, I’d love to hear if you ran into any trouble. I greatly appreciate any documentation improvements to make things more clear, I am not a native English speaker myself.
 
 See [CONTRIBUTING.md](CONTRIBUTING.md) for more information on how to contribute. You can also [just say thanks](https://github.com/gr2m/twitter-together/issues/new?labels=feature&template=04_thanks.md) 😊
 
@@ -103,7 +103,7 @@ For the `pull_request` event, the script handles only `opened` and `synchronize`
 
 ## Motivation
 
-I think we can make Open Source more inclusive to people with more diverse interests by making it easier to contribute other things than code and documentation. I see a particularly big opportunity to be more welcoming towards editorial contributions by creating tools using GitHub’s Acions, Apps and custom user interfaces backed by GitHub’s REST & GraphQL APIs.
+I think we can make Open Source more inclusive to people with more diverse interests by making it easier to contribute other things than code and documentation. I see a particularly big opportunity to be more welcoming towards editorial contributions by creating tools using GitHub’s Actions, Apps and custom user interfaces backed by GitHub’s REST & GraphQL APIs.
 
 I’ve plenty more ideas that I’d like to build out. Please ping me on twitter if you’d like to chat: [@gr2m](https://twitter.com/gr2m).
 

--- a/docs/01-create-twitter-app.md
+++ b/docs/01-create-twitter-app.md
@@ -6,7 +6,7 @@ You can create a twitter app for your twitter account at https://developer.twitt
 
 [![](twitter-01-create-an-app.png)](https://developer.twitter.com/en/apps)
 
-If you haven’t yet, you will be asked to apply for a Twitter developer account. See my answers below for reference. I’ve you’ve done that before, skip the next section and continue at [Create an app](#create-an-app).
+If you haven’t yet, you will be asked to apply for a Twitter developer account. See my answers below for reference. If you’ve done that before, skip the next section and continue at [Create an app](#create-an-app).
 
 ## Apply for a developer account
 

--- a/docs/01-create-twitter-app.md
+++ b/docs/01-create-twitter-app.md
@@ -1,4 +1,4 @@
-[back to README.md](../#setup)
+[back to README.md](../README.md/#setup)
 
 # Create a twitter app
 

--- a/docs/02-create-main.workflow.md
+++ b/docs/02-create-main.workflow.md
@@ -1,4 +1,4 @@
-[back to README.md](../#setup)
+[back to README.md](../README.md/#setup)
 
 # Create a `.github/main.workflow` file
 
@@ -41,4 +41,4 @@ action "Preview" {
 
 Nearly done! Shortly after creating or updating `.github/main.workflow` in your repository’s default branch, a pull request will be created with further instructions.
 
-[back to README.md](../#setup)
+[back to README.md](../README.md/#setup)

--- a/tweets/README.md
+++ b/tweets/README.md
@@ -16,7 +16,7 @@ You can use subfolders, e.g. `tweets/2019-02/hello-world.tweet`, as long as the 
 
 - Only newly created files are handled, deletions, updates or renames are ignored.
 - `*.tweet` files will not be created for tweets you send out directly from twitter.com
-- If you need to rename an existing tweet file, please do so locally using [`git mv old_filename new_filename`](https://help.github.com/en/articles/renaming-a-file-using-the-command-line), otherwise it may occure as deleted and added which would trigger a new tweet.
+- If you need to rename an existing tweet file, please do so locally using [`git mv old_filename new_filename`](https://help.github.com/en/articles/renaming-a-file-using-the-command-line), otherwise it may occur as deleted and added which would trigger a new tweet.
 
 ## Questions?
 


### PR DESCRIPTION
I corrected some typo and added the correct path to the main readme file from the readme files in the docs folder.

-----
[View rendered README.md](https://github.com/Eronmmer/twitter-together/blob/master/README.md)
[View rendered docs/01-create-twitter-app.md](https://github.com/Eronmmer/twitter-together/blob/master/docs/01-create-twitter-app.md)
[View rendered docs/02-create-main.workflow.md](https://github.com/Eronmmer/twitter-together/blob/master/docs/02-create-main.workflow.md)
[View rendered tweets/README.md](https://github.com/Eronmmer/twitter-together/blob/master/tweets/README.md)