### PR TITLE
docs: add mention of the twitter ads api version

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ For Open Source or event maintainers that share a project twitter account, `twit
 <!-- toc -->
 
 - [Try it](#try-it)
+- [Twitter API compatibility](#twitter-api-compatibility)
 - [Setup](#setup)
 - [Contribute](#contribute)
 - [How it works](#how-it-works)
@@ -31,6 +32,10 @@ For Open Source or event maintainers that share a project twitter account, `twit
 ## Try it
 
 You can submit a tweet to this repository to see the magic happen. Please follow the instructions at [tweets/README.md](tweets/README.md) and mention your own twitter username to the tweet. This repository is setup to tweet from [https://twitter.com/commit2tweet](https://twitter.com/commit2tweet).
+
+## Twitter API compatibility
+
+The Twitter Ads API we currently use is the `v8` version.
 
 ## Setup
 


### PR DESCRIPTION
I received an email about Twitter regarding the deprecation of v7. I came to the tool and had to check the source code to find which version we use so I guess adding it to the README could be a nice addition.