### PR TITLE
Set up semantic release to bump package version

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,12 @@
         }
       ],
       [
+        "@semantic-release/npm",
+        {
+          "npmPublish": false
+        }
+      ],
+      [
         "@semantic-release/git",
         {
           "assets": [


### PR DESCRIPTION
This PR adds an NPM module to semantic-release, which means that it will automatically bump the version in package.json if warranted before triggering a build/pushing a release to the v1 branch. Despite adding this module, configuration is set to ensure the only thing the NPM module does is bump the version locally before the rest of the release is run - all other functionality is skipped.

By bumping the package.json version just before a build occurs, we ensure that in the actions logs you can always notice what version of `twitter-together` is actually run at a specific time, instead of a generic `0.0.0-development` which remains constant between releases.

Bumping the version when the core code itself hasn't changed much may not be right, so I'm happy for you to offer guidance on how I can restrict bumps to when the core code itself has actually changed or for you to close this PR as not needed, if you think that is the right course of action.